### PR TITLE
Add support for character classes and line comments

### DIFF
--- a/grammars/nearley.cson
+++ b/grammars/nearley.cson
@@ -53,6 +53,7 @@
         'match': '[\\w\\?\\+]+'
       }
       {'include': '#strings'}
+      {'include': '#char_class'}
       {
         'begin': '\\('
         'beginCaptures': '0': 'name': 'meta.brace.round.nearley'
@@ -103,5 +104,30 @@
         'end': '\''
         'endCaptures': '0': 'name': 'punctuation.definition.string.end.php'
         'name': 'string.quoted.single.php'
+      }
+    ]
+
+  'char_class':
+    'begin': '\\['
+    'beginCaptures': '0': 'name': 'punctuation.definition.character-class.regexp'
+    'contentName': 'constant.character.character-class.regexp'
+    'end': '\\]'
+    'endCaptures': '0': 'name': 'punctuation.definition.character-class.regexp'
+    'patterns': [
+      {
+        'match': '\\^?[\\-\\]]?([^\\^\\-\\]\\\\]|\\\\.)*'
+      }
+    ]
+
+  'line_comments':
+    'begin': '(^[ \\t]+)?(?=\\#)'
+    'beginCaptures': '1': 'name': 'punctuation.whitespace.comment.leading.js'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'begin': '#'
+        'beginCaptures': '0': 'name': 'punctuation.definition.comment.js'
+        'end': '\\n'
+        'name': 'comment.line.double-slash.js'
       }
     ]


### PR DESCRIPTION
Lack of support for character classes and line comments was causing any contained quote characters to be treated as the beginning of a string literal. With these changes, `examples/javascript.ne` from the nearley repo now renders as expected.